### PR TITLE
Add parse distro

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 from setuptools import setup
 
 setup(name='saltrepoinspect',
-      version='0.1',
+      version='1.2',
       description='Tools to inspect a salt rpm repository',
       url='https://github.com/dincamihai/saltrepoinspect.git',
       author='Mihai Dincă',


### PR DESCRIPTION
I've added a new function `parse_distro` that is similar to `parse_version`. The main differences are that
a `nametuple("Distro", ["name", "major", "version_separator", "minor"])` is returned (for .name, .major etc. access) and some logic is added on top of the regular expression.

I also bumped the version and removed the novel repo fro `get_docker_params` since those repos are a thing of the past.